### PR TITLE
An additional check since the length of the PgnList[i].FieldList look…

### DIFF
--- a/nmea2k/raw_message.go
+++ b/nmea2k/raw_message.go
@@ -157,6 +157,11 @@ func ParsePacket(cmsg *can.RawMessage) (pgnParsed *ParsedMessage) {
 							i++
 							pgnDefinition = PgnList[i]
 							fields = pgnDefinition.FieldList
+
+							if idx >= len(fields) {
+								break
+							}
+
 							field = fields[idx]
 						}
 					} else {


### PR DESCRIPTION
…s to change throughout the loop. To avoid runtime errors then this seems to work.